### PR TITLE
Fixed major lag spikes with gab engine

### DIFF
--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -327,6 +327,7 @@ class PlayState extends MusicBeatState
 	override public function create()
 	{
 		Paths.clearStoredMemory();
+                Paths.clearUnusedMemory();
 
 		// for lua
 		instance = this;

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -175,7 +175,7 @@ class PlayState extends MusicBeatState
 	public var strumLineNotes:FlxTypedGroup<StrumNote>;
 	public var opponentStrums:FlxTypedGroup<StrumNote>;
 	public var playerStrums:FlxTypedGroup<StrumNote>;
-	public var grpNoteSplashes:FlxTypedGroup<NoteSplash>;
+	public var grpNoteSplashes:FlxTypedGroup<NoteSplash>; 
 
 	public var camZooming:Bool = false;
 	private var curSong:String = "";
@@ -1492,6 +1492,7 @@ class PlayState extends MusicBeatState
 		super.create();
 
 		Paths.clearUnusedMemory();
+                Paths.clearStoredMemory();
 		CustomFadeTransition.nextCamera = camOther;
 	}
 


### PR DESCRIPTION
Seriously, it almost crashed my damn game.

The clear unused memory, basically prevent's the memory going crack mode (ex: 1103.12 MB).
(now reduced from my math calculations: 330.97 MB, meaning it dropped 772 megabytes of storage)

Seriously, annoying as hell