### PR TITLE
added tiny but kinda useful feature

### DIFF
--- a/source/openfl/display/FPS.hx
+++ b/source/openfl/display/FPS.hx
@@ -87,7 +87,7 @@ class FPS extends TextField
 			var memoryMegas:Float = 0;
 			
 			#if openfl
-			memoryMegas = Math.abs(FlxMath.roundDecimal(System.totalMemory / 1000000, 1));
+			memoryMegas = Math.round(System.totalMemory / (1e+6));
                         if (memoryMegas > memoryPeak) memoryPeak = memoryMegas;
 
 			text += "\nMEM: " + memoryMegas + " RAM" + "\nMEM PEAK: " + memoryPeak + " RAM";


### PR DESCRIPTION
What this is supposed to be: It is actually (even more accurate) rounding up how much MB it is USING inside the game, while the 1e+6 thing is supposed to convert it over to MB's.

I can't get interval from forever engine sadly.